### PR TITLE
PWA ^6.1 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 
+## [2.0.0] - 2018-01-15
+
+### Changed
+- changed the product selectors to meet PWA 6.1 specification
+- dev dependencies update to PWA 6.x
+### Added
+- (🔥 breaking change) added peerDependency to shopgate/pwa-common-commerce@^6.1.0 to disallow deployments for PWA 5.x installations
+ 
 ## [1.0.1] - 2018-11-21
 ### Added
 - implemented hook to support shopgate-products 1.5.0
@@ -7,5 +15,6 @@
 ### Added
 - Extra Price info adding functionality
 
+[2.0.0]: https://github.com/shopgate/ext-add-extra-price-info-from-property/compare/v1.0.1...v2.0.0
 [1.0.1]: https://github.com/shopgate/ext-add-extra-price-info-from-property/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/shopgate/ext-add-extra-price-info-from-property/tree/v1.0.0

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "2.0.0",
   "id": "@shopgate/add-extra-price-info-from-property",
   "components": [
     {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate/add-extra-price-info-from-property",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "This extension is used to add information to prices acquired from a product property",
   "license": "Apache-2.0",
   "scripts": {
@@ -10,13 +10,12 @@
     "coverage:watch": "npm run coverage -- --watch"
   },
   "devDependencies": {
-    "@shopgate/eslint-config": "^5.7.3",
-    "@shopgate/pwa-common": "^5.2.0",
-    "@shopgate/pwa-common-commerce": "^5.2.0",
-    "@shopgate/pwa-core": "^5.2.0",
-    "@shopgate/pwa-ui-shared": "^5.7.4",
-    "@shopgate/pwa-unit-test": "^5.2.0",
-    "@shopgate/react-hammerjs": "^0.5.8",
+    "@shopgate/eslint-config": "^6.0.0",
+    "@shopgate/pwa-common": "^6.0.0",
+    "@shopgate/pwa-common-commerce": "^6.0.0",
+    "@shopgate/pwa-core": "^6.0.0",
+    "@shopgate/pwa-ui-shared": "^6.0.0",
+    "@shopgate/pwa-unit-test": "^6.0.0",
     "babel-core": "^6.26.0",
     "babel-plugin-react-transform": "^3.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
@@ -33,11 +32,14 @@
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-hot-loader": "4.0.1",
+    "react-hot-loader": "^4.0.1",
     "react-redux": "^5.0.7",
     "react-transform-catch-errors": "^1.0.2",
     "redbox-react": "^1.5.0",
     "redux-mock-store": "^1.5.3"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "peerDependencies": {
+    "@shopgate/pwa-common-commerce": "^6.1.0"
+  }
 }

--- a/frontend/portals/category/CategoryItemPrice/connector.js
+++ b/frontend/portals/category/CategoryItemPrice/connector.js
@@ -4,13 +4,13 @@ import { getExtraPriceInfoByProductId, getProductPriceById } from '../../../sele
 /**
  * Maps the contents of the state to the component props.
  * @param {Object} state The current application state.
- * @param {string} productId Given product.
+ * @param {Object} props Given product.
  * @return {Object} The extended component props.
  */
-const mapStateToProps = (state, { productId }) => (
+const mapStateToProps = (state, props) => (
   {
-    price: getProductPriceById(state, productId),
-    extraPriceInfo: getExtraPriceInfoByProductId(state, productId),
+    price: getProductPriceById(state, props),
+    extraPriceInfo: getExtraPriceInfoByProductId(state, props),
     viewMode: (state.ui && state.ui.categoryPage) ? state.ui.categoryPage.viewMode : '',
   }
 );

--- a/frontend/selectors/product.js
+++ b/frontend/selectors/product.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import {
   getProductById,
-  getCurrentProduct,
+  getProduct,
 } from '@shopgate/pwa-common-commerce/product/selectors/product';
 
 /**
@@ -51,6 +51,6 @@ export const getProductPriceById = createSelector(
  * @return {Object}
  */
 export const getCurrentProductExtraPriceInfo = createSelector(
-  getCurrentProduct,
+  getProduct,
   product => findExtraPriceInfo(product)
 );


### PR DESCRIPTION


## Description
🔥 Breaking change: PWA 6.1 dependency.

- changed the product selector to meet new requirements
- dev dependencies update
- added peerDependency to shopgate/pwa-common-commerce@^6.1.0
- version bump (2.0.0) (breaking change -> pwa 6.1 dependency)